### PR TITLE
HCK-7485: fix re api disconnect parameters inconsistency

### DIFF
--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -13,7 +13,7 @@ module.exports = {
 		gremlinHelper.connect(connectionInfo, logger, sshService).then(cb, cb);
 	},
 
-	disconnect: async function (connectionInfo, cb, app) {
+	disconnect: async function (connectionInfo, logger, cb, app) {
 		const sshService = app.require('@hackolade/ssh-service');
 		await gremlinHelper.close(sshService);
 		cb();
@@ -32,11 +32,11 @@ module.exports = {
 				gremlinHelper
 					.testConnection()
 					.then(() => {
-						this.disconnect(connectionInfo, () => {}, app);
+						this.disconnect(connectionInfo, logger, () => {}, app);
 						cb();
 					})
 					.catch(error => {
-						this.disconnect(connectionInfo, () => {}, app);
+						this.disconnect(connectionInfo, logger, () => {}, app);
 						logger.log('error', prepareError(error));
 						cb({ message: 'Connection error', stack: error.stack });
 					});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7485" title="HCK-7485" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-7485</a>  The disconnect action in plugin doesn’t work properly (all targets affected)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Used the `(connectionInfo, logger, cb, app)` argument set for disconnect function as with other endpoints to make the API consistent.