### PR TITLE
HCK-10586: add ipv6 escaping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"async": "3.2.5",
 				"gremlin": "3.7.3",
+				"ip": "2.0.1",
 				"lodash": "4.17.21"
 			},
 			"devDependencies": {
@@ -2774,6 +2775,12 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/ip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+			"integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+			"license": "MIT"
 		},
 		"node_modules/is-array-buffer": {
 			"version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "dependencies": {
         "async": "3.2.5",
         "gremlin": "3.7.3",
+        "ip": "2.0.1",
         "lodash": "4.17.21"
     },
     "lint-staged": {

--- a/reverse_engineering/gremlinHelper.js
+++ b/reverse_engineering/gremlinHelper.js
@@ -41,6 +41,7 @@ const {
 	getGraphTraversalSourceScriptFromConfiguredGraphFactory,
 	checkGraphTraversalSourceScriptFromConfiguredGraphFactory,
 } = require('./helpers/gremlinScriptsHelper');
+const { escapeV6IpForURL } = require('./helpers/escapeV6IPForURL');
 
 let sshTunnel;
 let client;
@@ -92,7 +93,7 @@ const connect = async (info, logger, sshService) => {
 
 const connectToInstance = (info, logger) => {
 	return new Promise((resolve, reject) => {
-		const host = (info.ssh && info.escapedHostForUrl) || info.host;
+		const host = (info.ssh && info.escapedHostForUrl) || escapeV6IpForURL({ host: info.host });
 		const port = info.port;
 		const username = info.username;
 		const password = info.password;

--- a/reverse_engineering/helpers/escapeV6IPForURL.js
+++ b/reverse_engineering/helpers/escapeV6IPForURL.js
@@ -1,28 +1,62 @@
 const ip = require('ip');
 
-//@see https://en.wikipedia.org/wiki/IPv6_address
-// Literal IPv6 addresses in resources (URLs):
-// ------------------------------------------------
-// Colon (:) characters in IPv6 addresses may conflict with the established syntax of resource identifiers,
-// such as URIs and URLs. The colon is conventionally used to terminate the host path before a port number.[10]
-// To alleviate this conflict, literal IPv6 addresses are enclosed in square brackets in such resource identifiers;
-// When the URL doesn't conatoin the port the notation is
-//      http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/
-// When the URL also contains a port number the notation is:
-//      https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443/
+/**
+ * @see https://en.wikipedia.org/wiki/IPv6_address
+ * Literal IPv6 addresses in resources (URLs):
+------------------------------------------------
+ * Colon (:) characters in IPv6 addresses may conflict with the established syntax of resource identifiers,
+ * such as URIs and URLs. The colon is conventionally used to terminate the host path before a port number.[10]
+ * To alleviate this conflict, literal IPv6 addresses are enclosed in square brackets in such resource identifiers;
+ * When the URL doesn't conatoin the port the notation is http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/
+ * When the URL also contains a port number the notation is: https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443/
+ *
+ * @param {{
+* 	host: string
+* }} param
+* @returns {string}
+*/
 function escapeV6IpForURL({ host }) {
-	// If the host is already URL compatible then the ip lib will return false
-	// > ip.isV6Format('[::1]')
-	// false
-	// If the host is a proper ipv6 ip then the `new URL(host)` will fail with Uncaught TypeError: Invalid URL
-	// code: 'ERR_INVALID_URL',
-	// !ip.isV4Format(host) check required because isV6Format returns true for ipv4 address because of backward compatibility
-
+	/**
+	 * If the host is already URL compatible then the ip lib will return false > ip.isV6Format('[::1]') false
+	 * If the host is a proper ipv6 ip then the `new URL(host)` will fail with Uncaught TypeError: Invalid URL code: 'ERR_INVALID_URL',
+	 * !ip.isV4Format(host) check required because isV6Format returns true for ipv4 address because of backward compatibility
+	 */
 	if (ip.isV6Format(host) && !ip.isV4Format(host)) {
 		return `[${host}]`;
 	}
 
-	return host;
+	const isUrlValid = isValidURL(host);
+	if (isUrlValid) {
+		return host;
+	}
+
+	const urlWithIpV6HostRegExp = new RegExp(/^http(s)?:\/\/(?<unescapedIpWithPort>([a-z0-9]{0,4}:?)+)/gim);
+	const { unescapedIpWithPort } = urlWithIpV6HostRegExp.exec(host)?.groups ?? {};
+
+	if (!unescapedIpWithPort) {
+		return host;
+	}
+
+	const separatedIpPortionsAndPort = unescapedIpWithPort.split(':');
+	const ipPortions = separatedIpPortionsAndPort.slice(0, separatedIpPortionsAndPort.length - 1);
+	const port = separatedIpPortionsAndPort.at(-1);
+	const escapedIpWithPort = `[${ipPortions.join(':')}]:${port}`;
+
+	return host.replace(unescapedIpWithPort, escapedIpWithPort);
+}
+
+/**
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isValidURL(url) {
+	try {
+		new URL(url);
+
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 module.exports = {

--- a/reverse_engineering/helpers/escapeV6IPForURL.js
+++ b/reverse_engineering/helpers/escapeV6IPForURL.js
@@ -1,0 +1,30 @@
+const ip = require('ip');
+
+//@see https://en.wikipedia.org/wiki/IPv6_address
+// Literal IPv6 addresses in resources (URLs):
+// ------------------------------------------------
+// Colon (:) characters in IPv6 addresses may conflict with the established syntax of resource identifiers,
+// such as URIs and URLs. The colon is conventionally used to terminate the host path before a port number.[10]
+// To alleviate this conflict, literal IPv6 addresses are enclosed in square brackets in such resource identifiers;
+// When the URL doesn't conatoin the port the notation is
+//      http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/
+// When the URL also contains a port number the notation is:
+//      https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443/
+function escapeV6IpForURL({ host }) {
+	// If the host is already URL compatible then the ip lib will return false
+	// > ip.isV6Format('[::1]')
+	// false
+	// If the host is a proper ipv6 ip then the `new URL(host)` will fail with Uncaught TypeError: Invalid URL
+	// code: 'ERR_INVALID_URL',
+	// !ip.isV4Format(host) check required because isV6Format returns true for ipv4 address because of backward compatibility
+
+	if (ip.isV6Format(host) && !ip.isV4Format(host)) {
+		return `[${host}]`;
+	}
+
+	return host;
+}
+
+module.exports = {
+	escapeV6IpForURL,
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10586" title="HCK-10586" target="_blank"><img alt="Task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />HCK-10586</a>  [Social Security Admin] Enclose ipv6 addresses in URLs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added ipv6 escaping